### PR TITLE
Abstract away CentralManager to hopefully ease uni testing

### DIFF
--- a/CoEpi.xcodeproj/project.pbxproj
+++ b/CoEpi.xcodeproj/project.pbxproj
@@ -23,12 +23,13 @@
 		84BF973024281082001ADD6B /* DataRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BF972A24281082001ADD6B /* DataRepresentable.swift */; };
 		84BF973124281082001ADD6B /* Types+DataRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BF972B24281082001ADD6B /* Types+DataRepresentable.swift */; };
 		84FA00F22427E13000318104 /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FA00F12427E13000318104 /* Dependencies.swift */; };
-		84FA00F52427E83000318104 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 84FA00F42427E83000318104 /* SwiftPackageProductDependency */; };
+		84FA00F52427E83000318104 /* Dip in Frameworks */ = {isa = PBXBuildFile; productRef = 84FA00F42427E83000318104 /* Dip */; };
 		84FA00FB2427ED1900318104 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FA00F92427ED1900318104 /* OnboardingViewController.swift */; };
 		84FA00FC2427ED1900318104 /* OnboardingViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84FA00FA2427ED1900318104 /* OnboardingViewController.xib */; };
 		84FA01002427ED5E00318104 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FA00FE2427ED5E00318104 /* HomeViewController.swift */; };
 		84FA01012427ED5E00318104 /* HomeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84FA00FF2427ED5E00318104 /* HomeViewController.xib */; };
 		CC71F7CAF64914F41BBE05C5 /* Pods_CoEpi_CoEpiUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AB30FDD8E48688E1BF91F91 /* Pods_CoEpi_CoEpiUITests.framework */; };
+		CE9E4B07242BCD8B00601E5B /* CentralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9E4B06242BCD8B00601E5B /* CentralManager.swift */; };
 		D7710CEB4F1D549EA29A856F /* Pods_CoEpiTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89B1FB101DD42773F3ADB2EC /* Pods_CoEpiTests.framework */; };
 		ED84885A0AB19A504317BA10 /* Pods_CoEpi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83D98C7D6EAEBFA0E5292E3F /* Pods_CoEpi.framework */; };
 /* End PBXBuildFile section */
@@ -86,6 +87,7 @@
 		89B1FB101DD42773F3ADB2EC /* Pods_CoEpiTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CoEpiTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		910DD69A29B6DF9226FCFECA /* Pods-CoEpiTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpiTests.debug.xcconfig"; path = "Target Support Files/Pods-CoEpiTests/Pods-CoEpiTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C12F75FF3B79C829E72E1CF6 /* Pods-CoEpi-CoEpiUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpi-CoEpiUITests.release.xcconfig"; path = "Target Support Files/Pods-CoEpi-CoEpiUITests/Pods-CoEpi-CoEpiUITests.release.xcconfig"; sourceTree = "<group>"; };
+		CE9E4B06242BCD8B00601E5B /* CentralManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CentralManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,7 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				84FA00F52427E83000318104 /* BuildFile in Frameworks */,
+				84FA00F52427E83000318104 /* Dip in Frameworks */,
 				ED84885A0AB19A504317BA10 /* Pods_CoEpi.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -127,7 +129,6 @@
 				910DD69A29B6DF9226FCFECA /* Pods-CoEpiTests.debug.xcconfig */,
 				324F4D7DC6C28946706D180E /* Pods-CoEpiTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -190,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				84BF972924281082001ADD6B /* Central.swift */,
+				CE9E4B06242BCD8B00601E5B /* CentralManager.swift */,
 				84BF972A24281082001ADD6B /* DataRepresentable.swift */,
 				84BF972624281082001ADD6B /* LogSettings.swift */,
 				84BF972724281082001ADD6B /* Peripheral.swift */,
@@ -266,7 +268,7 @@
 			);
 			name = CoEpi;
 			packageProductDependencies = (
-				84FA00F42427E83000318104 /* SwiftPackageProductDependency */,
+				84FA00F42427E83000318104 /* Dip */,
 			);
 			productName = CoEpi;
 			productReference = 849DFE622427D3750008ED65 /* CoEpi.app */;
@@ -344,7 +346,7 @@
 			);
 			mainGroup = 849DFE592427D3750008ED65;
 			packageReferences = (
-				84FA00F32427E83000318104 /* RemoteSwiftPackageReference */,
+				84FA00F32427E83000318104 /* XCRemoteSwiftPackageReference "Dip" */,
 			);
 			productRefGroup = 849DFE632427D3750008ED65 /* Products */;
 			projectDirPath = "";
@@ -507,6 +509,7 @@
 				849DFE702427D3750008ED65 /* CoEpi.xcdatamodeld in Sources */,
 				84FA00F22427E13000318104 /* Dependencies.swift in Sources */,
 				84FA01002427ED5E00318104 /* HomeViewController.swift in Sources */,
+				CE9E4B07242BCD8B00601E5B /* CentralManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -857,7 +860,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		84FA00F32427E83000318104 /* RemoteSwiftPackageReference */ = {
+		84FA00F32427E83000318104 /* XCRemoteSwiftPackageReference "Dip" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AliSoftware/Dip";
 			requirement = {
@@ -868,9 +871,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		84FA00F42427E83000318104 /* SwiftPackageProductDependency */ = {
+		84FA00F42427E83000318104 /* Dip */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 84FA00F32427E83000318104 /* RemoteSwiftPackageReference */;
+			package = 84FA00F32427E83000318104 /* XCRemoteSwiftPackageReference "Dip" */;
 			productName = Dip;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/CoEpi/ble/CentralManager.swift
+++ b/CoEpi/ble/CentralManager.swift
@@ -1,0 +1,96 @@
+//
+//  CentralManager.swift
+//  CoEpi
+//
+//  Created by Johnson Hsieh on 3/25/20.
+//  Copyright © 2020 org.coepi. All rights reserved.
+//
+
+import CoreBluetooth
+import os.log
+
+protocol CentralManager: NSObject {
+    var isScanning: Bool { get }
+    var bluetoothState: BluetoothState { get }
+    func scanForPeripherals(withServices serviceUUIDs: [String]?, allowDuplicates: Bool)
+    func connect(_ peripheral: CBPeripheral, options: [String : Any]?)
+    func cancelPeripheralConnection(_ peripheral: CBPeripheral)
+    func stopScan()
+}
+
+extension CBCentralManager : CentralManager {
+    var bluetoothState: BluetoothState {
+        os_log("Central manager did update state: %d", log: bleCentralLog, state.rawValue)
+        return BluetoothState(cbState: state)
+    }
+
+    func scanForPeripherals(withServices serviceUUIDs: [String]?, allowDuplicates: Bool) {
+        let options = [CBCentralManagerScanOptionAllowDuplicatesKey : NSNumber(booleanLiteral: allowDuplicates)]
+        scanForPeripherals(withServices: serviceUUIDs?.map { CBUUID(string: $0) }, options: options)
+    }
+}
+
+enum BluetoothState {
+    case active
+    case inactive
+    init(cbState: CBManagerState) {
+        switch cbState {
+        case .poweredOn:
+            self = .active
+        default:
+            self = .inactive
+        }
+    }
+}
+
+protocol CentralManagerDelegateInterface {
+    func didUpdateState(central: CentralManager)
+    func didDiscover(central: CentralManager, peripheral: CBPeripheral, advertisementData: [String: Any], RSSI: NSNumber)
+    func didConnect(central: CentralManager, peripheral: CBPeripheral)
+}
+
+class CentralManagerDelegate: CentralManagerDelegateInterface {
+    let shim: CentralManagerShim
+    init(didUpdateState: @escaping (_ central: CBCentralManager) -> (),
+         didDiscover: @escaping(_ central: CBCentralManager, _ peripheral: CBPeripheral, _ advertisementData: [String: Any], _ RSSI: NSNumber) -> (),
+         didConnect: @escaping(_ central: CBCentralManager, _ peripheral: CBPeripheral) -> ()) {
+        shim = CentralManagerShim(didUpdateState: didUpdateState, didDiscover: didDiscover, didConnect: didConnect)
+    }
+
+    func didUpdateState(central: CentralManager) {
+        shim.centralManagerDidUpdateState(central as! CBCentralManager)
+    }
+    func didDiscover(central: CentralManager, peripheral: CBPeripheral, advertisementData: [String : Any], RSSI: NSNumber) {
+        shim.centralManager(central as! CBCentralManager, didDiscover: peripheral, advertisementData: advertisementData, rssi: RSSI)
+    }
+    func didConnect(central: CentralManager, peripheral: CBPeripheral) {
+        shim.centralManager(central as! CBCentralManager, didConnect: peripheral)
+    }
+}
+
+class CentralManagerShim: NSObject, CBCentralManagerDelegate {
+    let didUpdateState: (_ central: CBCentralManager) -> ()
+    let didDiscover: (_ central: CBCentralManager, _ peripheral: CBPeripheral, _ advertisementData: [String: Any], _ RSSI: NSNumber) -> ()
+    let didConnect: (_ central: CBCentralManager, _ peripheral: CBPeripheral) -> ()
+    init(didUpdateState: @escaping (_ central: CBCentralManager) -> (),
+         didDiscover: @escaping(_ central: CBCentralManager, _ peripheral: CBPeripheral, _ advertisementData: [String: Any], _ RSSI: NSNumber) -> (),
+         didConnect: @escaping(_ central: CBCentralManager, _ peripheral: CBPeripheral) -> ()) {
+        self.didUpdateState = didUpdateState
+        self.didDiscover = didDiscover
+        self.didConnect = didConnect
+    }
+
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        didUpdateState(central)
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
+                        advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        didDiscover(central, peripheral, advertisementData, RSSI)
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        didConnect(central, peripheral)
+    }
+
+}


### PR DESCRIPTION
The goal here is to remove references to `CoreBluetooth` in our business logic (`Central.swift`), which should make it easier to do unit testing. If we care about unit testing, some solution is necessary here, particularly because `init()` is unavailable for a lot of the frequently used CB types (`CBPeripheral`, `CBService`, `CBCharacteristic`).

In this PR, I abstract away `CBCentralManager`, by creating a `CentralManager` protocol for our business logic to use. Both the real `CBCentralManager` and a future mock would conform. Plus a few random notes/questions.

On the delegate side, I create a delegate protocol which (would eventually) not reference `CoreBluetooth` at all for business logic. The implementation uses a dumb shim around the delegate to make it easier to use. In the implementation it should be safe to `as! CBCentralManager` because the implementation should only be used when the app is really running (vs testing).

I think this marginally improves testability of `CentralManager` related code. The problem is that to fully pull out all `CoreBluetooth` references gets pretty hairy, because there's a bunch of `CB` types - `CBPeripherals`, `CBServices`, `CBCharacteristics`, etc, that reference each other, are passed into each others functions, etc. 

I'm probably most of the way to there: https://github.com/Co-Epi/app-ios/compare/master...johnsonh:BLE-abstract?expand=1. Most of the types are concrete, rather than protocols, so I wrap them in business objects that we can define. I've successfully gotten rid of the `CoreBluetooth` dependency in `Central`, which I renamed to `BluetoothManager`. 

However, things got fairly hairy, I've introduced a lot of protocols and types, and it's probably riddled with bugs that I'd need to spend time ironing out. I'm happy to do so if we think it's worthwhile. Due to `init()` not being available for a lot of the CB types, I think mocking/testing this code will require some non trivial solution. Alternatively to fully abstracting away CB types, I found 2 libraries for bluetooth helper types:
- https://github.com/Rightpoint/RZBluetooth
- https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock

Not sure how reliable they are. 