### PR TITLE
CEN matching: generate candidate CENs for each locally stored CEN

### DIFF
--- a/CoEpi/dao/RealmCENDao.swift
+++ b/CoEpi/dao/RealmCENDao.swift
@@ -5,6 +5,7 @@ protocol CENDao {
     func insert(cen: CEN) -> Bool
     func loadAllCENRecords() -> [CEN]?
     func match(start: Int64, end: Int64, hexEncodedCENs: [String]) -> [CEN]
+    func loadCensForTimeInterval(start: Int64, end: Int64) -> [CEN]
 }
 
 class RealmCENDao: CENDao, RealmDao {
@@ -39,5 +40,13 @@ class RealmCENDao: CENDao, RealmDao {
     func loadAllCENRecords() -> [CEN]? {
         let DBCENObject = realm.objects(RealmCEN.self).sorted(byKeyPath: "timestamp", ascending: false)
         return DBCENObject.map { CEN(CEN: $0.CEN, timestamp: $0.timestamp) }
+    }
+    
+    func loadCensForTimeInterval(start: Int64, end: Int64) -> [CEN] {
+        realm.objects(RealmCEN.self)
+            .filter("timestamp >= %d", start)
+            .filter("timestamp <= %d", end)
+            .compactMap { CEN(CEN: $0.CEN, timestamp: $0.timestamp)
+        }
     }
 }

--- a/CoEpi/domain/logic/CenLogic.swift
+++ b/CoEpi/domain/logic/CenLogic.swift
@@ -4,7 +4,7 @@ import os.log
 
 class CenLogic {
     private let CENKeyLifetimeInSeconds: Int64 = 7 * 86400
-    private let CENLifetimeInSeconds: Int64 = 15 * 60
+    static let CENLifetimeInSeconds: Int64 = 15 * 60
 
     func shouldGenerateNewCenKey(curTimestamp: Int64, cenKeyTimestamp: Int64) -> Bool {
          (cenKeyTimestamp == 0) || (roundedTimestamp(ts: curTimestamp, roundingInterval: CENKeyLifetimeInSeconds) > roundedTimestamp(ts: cenKeyTimestamp, roundingInterval: CENKeyLifetimeInSeconds))
@@ -34,7 +34,7 @@ class CenLogic {
 
         //convert timestamp to [UInt8]
         var tsAsUInt8Array: [UInt8] = []
-        [roundedTimestamp(ts: timestamp, roundingInterval: CENLifetimeInSeconds)].withUnsafeBytes {
+        [roundedTimestamp(ts: timestamp, roundingInterval: CenLogic.CENLifetimeInSeconds)].withUnsafeBytes {
             tsAsUInt8Array.append(contentsOf: $0)
         }
 

--- a/CoEpi/repo/CENRepo.swift
+++ b/CoEpi/repo/CENRepo.swift
@@ -7,6 +7,8 @@ protocol CENRepo {
     func loadAllCENRecords() -> [CEN]?
 
     func match(start: Int64, end: Int64, hexEncodedCENs: [String]) -> [CEN]
+    
+    func loadCensForTimeInterval(start: Int64, end: Int64) -> [CEN]
 }
 
 class CENRepoImpl: CENRepo {
@@ -26,5 +28,9 @@ class CENRepoImpl: CENRepo {
 
     func match(start: Int64, end: Int64, hexEncodedCENs: [String]) -> [CEN] {
         cenDao.match(start: start, end: end, hexEncodedCENs: hexEncodedCENs)
+    }
+    
+    func loadCensForTimeInterval(start: Int64, end: Int64) -> [CEN] {
+        cenDao.loadCensForTimeInterval(start: start, end: end)
     }
 }

--- a/CoEpi/repo/CoepiRepo.swift
+++ b/CoEpi/repo/CoepiRepo.swift
@@ -53,14 +53,16 @@ class CoEpiRepoImpl: CoEpiRepo {
 //            })
 
             // Filter matching keys
-            .map { keys -> [CENKey] in keys.compactMap { key in
-                if (cenMatcher.hasMatches(key: key, maxTimestamp: CoEpiRepoImpl.lastCENKeysCheck)) {
-                    return key
-                } else {
-                    return nil
-                }
-            }}
-
+//            .map { keys -> [CENKey] in keys.compactMap { key in
+//                if (cenMatcher.hasMatches(key: key, maxTimestamp: CoEpiRepoImpl.lastCENKeysCheck)) {
+//                    return key
+//                } else {
+//                    return nil
+//                }
+//            }}
+            
+            .map{keys -> [CENKey] in cenMatcher.matchLocalFirst(keys: keys, maxTimestamp: Date().coEpiTimestamp) }
+            
             .do(onNext: { matchedKeys in
                 if let matchingStartTime = matchingStartTime {
                     let time = CFAbsoluteTimeGetCurrent() - matchingStartTime


### PR DESCRIPTION
Fetch local CENs from Realm.
Fetch new keys from API.
For each local CEN:
   ts = cen.timestamp
   For each key:
      generate candidate CEN: f(key, rounded(ts))
      if localCen == candidatCen -> match found
...

For 2 local CENs matching time is ~4sec.
It should grow linearly with number of stored CENs.