### PR TITLE
add smell question to reminder notification

### DIFF
--- a/CoEpi/en.lproj/Localizable.strings
+++ b/CoEpi/en.lproj/Localizable.strings
@@ -170,5 +170,5 @@
 
     // local notification reminder
 "reminder.notification.title" = "Do you have any symptoms?";
-"reminder.notification.body" = "Remember to report any symptoms you might be experiencing.";
+"reminder.notification.body" = "Remember to report any symptoms you might be experiencing. Have you checked if you can smell today?";
 


### PR DESCRIPTION
Per https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7265845/ and many other studies, loss of smell (anosmia) can be an indicator of potential COVID-19 (otherwise occurring 2% of the time in other illnesses), and may be the main symptom people notice if they are otherwise asymptomatic. Prompting people to check their smell (can be as easy as washing hands and smelling the soap smell, or smelling hand sanitizer) is an easy low-cost thing people can do and also prompt them, if they're losing or have lost smell, to catalogue any other symptoms they are having.